### PR TITLE
FIXED - quick fix for issue #6

### DIFF
--- a/src/js/components/download.js
+++ b/src/js/components/download.js
@@ -5,7 +5,7 @@ export const registerDownloadComponent = (item, el, labelButtonDownload, allowDo
     const info = el.querySelector('.filepond--file-info-main'),
           downloadIcon = getDownloadIcon(labelButtonDownload);
 
-    info.prepend(downloadIcon);
+    info.innerHTML = downloadIcon.outerHTML + item.file.name;
     downloadIcon.addEventListener("click", () => downloadFile(item, allowDownloadByUrl));
 }
 


### PR DESCRIPTION
Hello,

I think it's a fix for #6 

In my case when I used the fieldset to display previously uploaded files (https://pqina.nl/filepond/docs/api/instance/properties/#files ), the plugin displayed the value of the input rather than the file name.
