### PR TITLE
Open the file in a new tab

### DIFF
--- a/src/js/components/download.js
+++ b/src/js/components/download.js
@@ -25,7 +25,7 @@ export const getDownloadIcon = (labelButtonDownload) => {
 export const downloadFile = (item, allowDownloadByUrl) => {
     // if client want to download file from remote server
     if(allowDownloadByUrl && item.getMetadata('url')) {
-        location.href = item.getMetadata('url'); // full path to remote server is stored in metadata with key 'url'
+        window.open(item.getMetadata('url'), '_blank'); // full path to remote server is stored in metadata with key 'url'
       } else {
         // create a temporary hyperlink to force the browser to download the file
         const a = document.createElement("a");


### PR DESCRIPTION
Some files that are not forcibly downloaded (like a pdf) just open in the same page instead (which is definitely not wanted)